### PR TITLE
fix: return if kenkoukun is not in VC

### DIFF
--- a/internal/kenkou.go
+++ b/internal/kenkou.go
@@ -37,6 +37,17 @@ func PlayHotaru(session *discordgo.Session, guildID string, channelID string) {
 }
 
 func ForceKenkou(session *discordgo.Session, guildID string, channelID string) {
+	forceFlag := false
+	for k, v := range session.VoiceConnections {
+		if k == guildID && v.ChannelID == channelID {
+			forceFlag = true
+		}
+	}
+	if !forceFlag {
+		log.Println(">< I'm not in VC.")
+		return
+	}
+
 	guild, err := session.Guild(guildID)
 	if err != nil {
 		log.Fatalf("Can't get guild: %v", err)


### PR DESCRIPTION
### 概要
- Close: #9 

### 詳細
Channel ID が一致する VoiceConnection が存在すれば force 実行、しなければ return するように変更